### PR TITLE
Add Top Delivered Shippers and Top RTS Shippers sections to performance dashboard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 - [x] Check performance-report.tsx and other components for similar display issues or unused code
 - [x] Run npm run dev to test the application
 - [x] Use browser to verify the analytical report displays correctly (server running on localhost:3000)
+- [x] Add Top Delivered Shippers and Top RTS Shippers sections to performance dashboard

--- a/components/performance-report.tsx
+++ b/components/performance-report.tsx
@@ -21,6 +21,8 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
     metrics,
     topProvinces,
     topRegions,
+    topDeliveredShippers,
+    topRtsShippers,
     regionSuccessRates,
     regionRTSRates,
   } = useMemo(() => {
@@ -29,6 +31,8 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
         metrics: null,
         topProvinces: [],
         topRegions: [],
+        topDeliveredShippers: [],
+        topRtsShippers: [],
         regionSuccessRates: [],
         regionRTSRates: [],
       }
@@ -92,6 +96,16 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
       regionCounts[parcel.region] = (regionCounts[parcel.region] || 0) + 1
     })
     const topRegions = Object.entries(regionCounts)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+
+    // Top Delivered Shippers
+    const topDeliveredShippers = Object.entries(sourceData.winningShippers)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+
+    // Top RTS Shippers
+    const topRtsShippers = Object.entries(sourceData.rtsShippers)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 10)
 
@@ -159,6 +173,8 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
       },
       topProvinces,
       topRegions,
+      topDeliveredShippers,
+      topRtsShippers,
       regionSuccessRates,
       regionRTSRates,
     }
@@ -377,8 +393,41 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
             ))}
           </div>
         </div>
+      </div>
 
+      {/* Top Shippers */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Top Delivered Shippers */}
+        <div className="glass rounded-xl p-6 border border-green-500/50">
+          <h3 className="text-xl font-bold text-foreground mb-4">Top Delivered Shippers</h3>
+          <div className="space-y-3 max-h-64 overflow-y-auto">
+            {topDeliveredShippers.map(([shipper, count], index) => (
+              <div key={shipper} className="flex items-center justify-between p-3 rounded-lg bg-green-500/10">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-bold text-green-500 w-6">#{index + 1}</span>
+                  <span className="text-sm font-medium text-foreground">{shipper}</span>
+                </div>
+                <span className="text-sm font-bold text-green-500">{count.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
 
+        {/* Top RTS Shippers */}
+        <div className="glass rounded-xl p-6 border border-red-500/50">
+          <h3 className="text-xl font-bold text-foreground mb-4">Top RTS Shippers</h3>
+          <div className="space-y-3 max-h-64 overflow-y-auto">
+            {topRtsShippers.map(([shipper, count], index) => (
+              <div key={shipper} className="flex items-center justify-between p-3 rounded-lg bg-red-500/10">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-bold text-red-500 w-6">#{index + 1}</span>
+                  <span className="text-sm font-medium text-foreground">{shipper}</span>
+                </div>
+                <span className="text-sm font-bold text-red-500">{count.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* Region Performance */}


### PR DESCRIPTION
This PR adds new data sections to the performance dashboard: Top Delivered Shippers and Top RTS Shippers, displaying the top 10 shippers by delivered and RTS parcel counts respectively.