### PR TITLE
Change RTS computation to only include RETURNED status, exclude CANCELLED

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - [x] Run npm run dev to test the application
 - [x] Use browser to verify the analytical report displays correctly (server running on localhost:3000)
 - [x] Add Top Delivered Shippers and Top RTS Shippers sections to performance dashboard
+- [x] Change RTS computation to only include RETURNED status, exclude CANCELLED

--- a/components/performance-report.tsx
+++ b/components/performance-report.tsx
@@ -63,7 +63,7 @@ export function PerformanceReport({ data }: PerformanceReportProps) {
     // Calculate metrics
     const totalParcels = filteredData.length
     const deliveredParcels = filteredData.filter((p) => p.normalizedStatus === "DELIVERED").length
-    const rtsStatuses = ["CANCELLED", "RETURNED"]
+    const rtsStatuses = ["RETURNED"]
     const rtsParcels = filteredData.filter((p) => rtsStatuses.includes(p.normalizedStatus))
     const rtsCount = rtsParcels.length
 

--- a/lib/excel-processor.ts
+++ b/lib/excel-processor.ts
@@ -166,7 +166,7 @@ function processData(excelData: unknown[][]): ProcessedData {
         }
       }
 
-      const rtsStatuses = ["CANCELLED", "RETURNED"]
+    const rtsStatuses = ["RETURNED"]
       if (rtsStatuses.includes(status)) {
         processedData.all.rtsShippers[shipper as string] = (processedData.all.rtsShippers[shipper as string] || 0) + 1
         if (processedData[island]) {


### PR DESCRIPTION
This PR updates the RTS computation logic to only consider parcels with 'RETURNED' status, excluding 'CANCELLED' status from RTS calculations. This affects RTS rate, total cost of returns, average RTS cost, region RTS rates, and top RTS shippers metrics.